### PR TITLE
Preview6 changes

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -82,7 +82,7 @@ stages:
         Write-Verbose -Verbose "Importing PSPackageProject from: $modPath"
         Import-Module -Name $modPath -Force
         #
-        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release
+        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework net472
       displayName: Build and publish artifact
 
     - pwsh: |
@@ -217,14 +217,12 @@ stages:
       displayName: PowerShell Core on Windows
       imageName: windows-2019
 
-  # Tests do not run under Windows PowerShell
-  # because of missing Dictionary.TryAdd() method.
-  #- template: test.yml
-  #  parameters:
-  #    jobName: TestPkgWinPS
-  #    displayName: Windows PowerShell on Windows
-  #    imageName: windows-2019
-  #    powershellExecutable: powershell
+  - template: test.yml
+    parameters:
+      jobName: TestPkgWinPS
+      displayName: Windows PowerShell on Windows
+      imageName: windows-2019
+      powershellExecutable: powershell
 
   - template: test.yml
     parameters:

--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -82,7 +82,7 @@ stages:
         Write-Verbose -Verbose "Importing PSPackageProject from: $modPath"
         Import-Module -Name $modPath -Force
         #
-        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework net472
+        $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release
       displayName: Build and publish artifact
 
     - pwsh: |
@@ -169,12 +169,12 @@ stages:
       displayName: Capture environment for ref assembly nuget file signing
       condition: and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True'))
 
-    - template: ./templates/sign.yml
+    - template: ./templates/sign-nuget.yml
       parameters:
         buildOutputPath: $(signSrcPath)
         signOutputPath: $(signOutPath)
         certificateId: "CP-401405"
-        pattern: '*.dll,*.psd1,*.ps1xml'
+        pattern: '*.nupkg'
 
     - pwsh: |
         $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'
@@ -192,6 +192,7 @@ stages:
         {
           $refAssemblyNuGetPath = Resolve-Path -Path "$($config.SignedOutputPath)/RefAssemblyNuGet/Microsoft.PowerShell.SecretManagement.Library*.nupkg"
         }
+        Get-ChildItem $config.SignedOutputPath -Recurse
         Get-ChildItem $refAssemblyNuGetPath
         $artifactName = "RefAssemblyNuGet"
         Write-Host "##vso[artifact.upload containerfolder=$artifactName;artifactname=$artifactName;]$refAssemblyNuGetPath"

--- a/.ci/templates/sign-nuget.yml
+++ b/.ci/templates/sign-nuget.yml
@@ -1,0 +1,50 @@
+parameters:
+  - name: "buildOutputPath"
+    default: "$(Build.ArtifactStagingDirectory)\\build"
+  - name: "signOutputPath"
+    default: "$(Build.ArtifactStagingDirectory)\\signed"
+  - name: "pattern"
+    default: "*.nupkg"
+  - name: "certificateId"
+    default: "CP-401405"
+
+steps:
+- pwsh: |
+    [string] $CertificateId = "${{ parameters.certificateId }}"
+    Write-Verbose "CertificateId - $CertificateId" -Verbose
+    [string] $VariableName = "EsrpJson"
+    $esrp = @(
+        @{
+         keyCode = $CertificateId
+         operationSetCode = "NuGetSign"
+         toolName = "sign"
+         toolVersion = "1.0"
+        }
+    )
+    $vstsCommandString = "vso[task.setvariable variable=$VariableName][$($esrp | ConvertTo-Json -Compress)]"
+    Write-Verbose -Message ("sending " + $vstsCommandString) -Verbose
+    Write-Host "##$vstsCommandString"
+    $vstsCommandString = "vso[task.setvariable variable=GDN_CODESIGN_TARGETDIRECTORY]${{ parameters.signOutputPath }}"
+    Write-Verbose -Message ("sending " + $vstsCommandString) -Verbose
+    Write-Host "##$vstsCommandString"
+  displayName: Generate signing JSON
+  condition: and(and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True')), ne(variables['SigningServer'], ''))
+
+- pwsh: |
+    Write-Verbose "BUILD_OUTPUT_PATH- ${{ parameters.buildOutputPath}}" -Verbose
+    Write-Verbose "SIGNED_OUTPUT_PATH- ${{ parameters.signOutputPath }}" -Verbose
+    Copy-Item ${{ parameters.buildOutputPath }}\* ${{ parameters.signOutputPath }}\ -Recurse -Force -Verbose
+  displayName: Prepare output folder
+  timeoutInMinutes: 10
+  condition: and(and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True')), ne(variables['SigningServer'], ''))
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: Sign files
+  inputs:
+    ConnectedServiceName: pwshSigning
+    FolderPath: '${{ parameters.signOutputPath }}'
+    UseMinimatch: false
+    signConfigType: inlineSignParams
+    inlineOperation: $(EsrpJson)
+    Pattern: ${{ parameters.pattern }}
+  condition: and(and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True')), ne(variables['SigningServer'], ''))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+## 0.5.5-Preview5 - 2020-11-16
+
+### Fixes
+
+- Incompatibility with WindowsPowerShell 5.1 (Issue #73)
+
+### Changes
+
+- The first extension vault added will automatically be designated the default vault (Issue #61)
+
+- `Unregister-SecretVault` `-Name` property now supports string[] type and wild cards (Issue #57,#58)
+
+- `Register-SecretVault` now checks `-VaultParameters` hashtable for reserved `Verbose` entry and throws error if found
+
+- `Set-DefaultVault` now has a `-ClearDefault` parameter that designates no registered vault as the default vault
+
+### New Features
+
+- `Register-SecretVault` now supports a `-Description` parameter and registration information will include an optional extension vault description (Issue #46)
+
 ## 0.5.4-Preview5 - 2020-11-4
 
 ### Fixes

--- a/Docs/DesignDoc.md
+++ b/Docs/DesignDoc.md
@@ -107,6 +107,36 @@ Tests that extension vault functions and returns True or diagnostic errors
 
 This function is called if provided by the extension vault, to allow the extension vault to perform an clean up tasks before the vault extension is unregistered
 
+#### Verbose and AdditionalParameters
+
+Each extension vault function takes a set of parameter arguments that includes an `AdditionalParameters` hash table.
+The values of the hash table come from the `VaultParameters` field of the registered vault, which are additional parameters an extension vault implementation might need beyond the specific parameters of a particular function.
+The `AdditionalParameters` hash table can also include an automatic `Verbose` boolean parameter.
+If the extension vault function is being called with the `-Verbose` common parameter, then the `Verbose` boolean parameter will be included in the `AdditionalParameters` hash table.
+The `Verbose` parameter is reserved and provided automatically by SecretManagement when verbose output is specified.
+It cannot be included in `VaultParameters`.
+
+Example:
+
+```powershell
+function Get-Secret
+{
+    [CmdletBinding()]
+    param (
+        [string] $Name,
+        [string] $VaultName,
+        [hashtable] $AdditionalParameters
+    )
+
+    # Enable verbose output if directed
+    if ($AdditionalParameters.ContainsKey('Verbose') -and ($AdditionalParameters['Verbose'] -eq $true)) {
+        $VerbosePreference = 'Continue'
+    }
+
+    ...
+}
+```
+
 ### Script module vault extension example
 
 This is a minimal vault extension example to demonstrate the directory structure and functional requirements of an extension vault module.

--- a/build.ps1
+++ b/build.ps1
@@ -36,8 +36,8 @@ param (
     [ValidateSet("Debug", "Release")]
     [string] $BuildConfiguration = "Debug",
 
-    [ValidateSet("netstandard2.0")]
-    [string] $BuildFramework = "netstandard2.0"
+    [ValidateSet("netstandard2.0","net472","net461")]
+    [string] $BuildFramework = "net472"
 )
 
 if ( ! (Get-Module -ErrorAction SilentlyContinue PSPackageProject -ListAvailable) ) {

--- a/build.ps1
+++ b/build.ps1
@@ -36,8 +36,8 @@ param (
     [ValidateSet("Debug", "Release")]
     [string] $BuildConfiguration = "Debug",
 
-    [ValidateSet("netstandard2.0","net472","net461")]
-    [string] $BuildFramework = "net472"
+    [ValidateSet("net461")]
+    [string] $BuildFramework = "net461"
 )
 
 if ( ! (Get-Module -ErrorAction SilentlyContinue PSPackageProject -ListAvailable) ) {

--- a/help/Register-SecretVault.md
+++ b/help/Register-SecretVault.md
@@ -14,7 +14,7 @@ Registers a SecretManagement extension vault module for the current user.
 
 ```
 Register-SecretVault [-ModuleName] <string> [[-Name] <string>] [-VaultParameters <Hashtable>] [-DefaultVault]
-[-AllowClobber] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-AllowClobber] [-PassThru] [-Description <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -78,6 +78,21 @@ This parameter switch makes the new extension vault the default vault for the cu
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+This parameter takes a description string that is included in the vault registry information.
+
+```yaml
+Type: string
 Parameter Sets: (All)
 Aliases:
 

--- a/help/Set-DefaultVault.md
+++ b/help/Set-DefaultVault.md
@@ -22,6 +22,11 @@ Set-DefaultVault [-Name] <string> [-WhatIf] [-Confirm] [<CommonParameters>]
 Set-DefaultVault [-SecretVault] <SecretVaultInfo> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### ClearParameterSet
+```
+Set-DefaultVault [-ClearDefault] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 This cmdlet updates the vault registry to indicate the provided vault name as the default vault.
 Only one registered vault can be the default vault.
@@ -63,7 +68,23 @@ The 'Get-SecretVault' is run once again to verify there is no default vault.
 
 ## PARAMETERS
 
+### -ClearDefault
+Makes no registered vault the default vault.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ClearParameterSet
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Name
+Name of registered vault to be made the default vault.
 
 ```yaml
 Type: String
@@ -78,6 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -SecretVault
+A SecretVaultInfo object that represents the registered vault to be made the default vault.
 
 ```yaml
 Type: SecretVaultInfo

--- a/help/Unregister-SecretVault.md
+++ b/help/Unregister-SecretVault.md
@@ -14,7 +14,7 @@ Un-registers an extension vault from SecretManagement for the current user.
 
 ### NameParameterSet
 ```
-Unregister-SecretVault [-Name] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Unregister-SecretVault [-Name] <string[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### SecretVaultParameterSet
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 Name of the vault to un-register.
 
 ```yaml
-Type: String
+Type: string[]
 Parameter Sets: NameParameterSet
 Aliases:
 
@@ -106,7 +106,7 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -SecretVault

--- a/help/en-US/Microsoft.PowerShell.SecretManagement.dll-Help.xml
+++ b/help/en-US/Microsoft.PowerShell.SecretManagement.dll-Help.xml
@@ -399,6 +399,18 @@ LocalStore Microsoft.PowerShell.SecretStore  True</dev:code>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:Description>
+            <maml:para>This parameter takes a description string that is included in the vault registry information.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">string</command:parameterValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>PassThru</maml:name>
           <maml:Description>
             <maml:para>When used this parameter will return the SecretVaultInfo object for the successfully registered extension vault.</maml:para>
@@ -470,6 +482,18 @@ LocalStore Microsoft.PowerShell.SecretStore  True</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Description</maml:name>
+        <maml:Description>
+          <maml:para>This parameter takes a description string that is included in the vault registry information.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">string</command:parameterValue>
+        <dev:type>
+          <maml:name>string</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
         <maml:name>ModuleName</maml:name>
@@ -676,10 +700,24 @@ Get-Secret: The secret secretTest was not found.</dev:code>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Set-DefaultVault</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>ClearDefault</maml:name>
+          <maml:Description>
+            <maml:para>Makes no registered vault the default vault.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-DefaultVault</maml:name>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
           <maml:name>Name</maml:name>
           <maml:Description>
-            <maml:para></maml:para>
+            <maml:para>Name of registered vault to be made the default vault.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -694,7 +732,7 @@ Get-Secret: The secret secretTest was not found.</dev:code>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
           <maml:name>SecretVault</maml:name>
           <maml:Description>
-            <maml:para></maml:para>
+            <maml:para>A SecretVaultInfo object that represents the registered vault to be made the default vault.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">SecretVaultInfo</command:parameterValue>
           <dev:type>
@@ -706,10 +744,22 @@ Get-Secret: The secret secretTest was not found.</dev:code>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>ClearDefault</maml:name>
+        <maml:Description>
+          <maml:para>Makes no registered vault the default vault.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>Name</maml:name>
         <maml:Description>
-          <maml:para></maml:para>
+          <maml:para>Name of registered vault to be made the default vault.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -721,7 +771,7 @@ Get-Secret: The secret secretTest was not found.</dev:code>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>SecretVault</maml:name>
         <maml:Description>
-          <maml:para></maml:para>
+          <maml:para>A SecretVaultInfo object that represents the registered vault to be made the default vault.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">SecretVaultInfo</command:parameterValue>
         <dev:type>
@@ -1172,14 +1222,14 @@ True</dev:code>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Unregister-SecretVault</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="none">
           <maml:name>Name</maml:name>
           <maml:Description>
             <maml:para>Name of the vault to un-register.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">string[]</command:parameterValue>
           <dev:type>
-            <maml:name>String</maml:name>
+            <maml:name>string[]</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1258,14 +1308,14 @@ True</dev:code>
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="none">
         <maml:name>Name</maml:name>
         <maml:Description>
           <maml:para>Name of the vault to un-register.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">string[]</command:parameterValue>
         <dev:type>
-          <maml:name>String</maml:name>
+          <maml:name>string[]</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/src/Microsoft.PowerShell.SecretManagement.psd1
+++ b/src/Microsoft.PowerShell.SecretManagement.psd1
@@ -7,7 +7,7 @@
 RootModule = '.\Microsoft.PowerShell.SecretManagement.dll'
 
 # Version number of this module.
-ModuleVersion = '0.5.4'
+ModuleVersion = '0.5.5'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')
@@ -75,7 +75,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        Prerelease = 'preview5'
+        Prerelease = 'preview6'
 
         # Flag to indicate whether the module requires explicit user acceptance for install/update/save
         # RequireLicenseAcceptance = $false

--- a/src/code/Microsoft.PowerShell.SecretManagement.Library.nuspec
+++ b/src/code/Microsoft.PowerShell.SecretManagement.Library.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.PowerShell.SecretManagement.Library</id>
-    <version>0.5.4-preview.5</version>
+    <version>0.5.5-preview.6</version>
     <title>Microsoft.PowerShell.SecretManagement.Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft,PowerShell</owners>
@@ -15,7 +15,7 @@
     <tags>PowerShell, SecretManagement, reference</tags>
     <language>en-US</language>
     <dependencies>
-      <group targetFramework=".NETStandard2.0">
+      <group targetFramework=".NETFramework4.6.1 ">
         <dependency id="Microsoft.CSharp" version="4.5.0" exclude="Build,Analyzers" />
         <dependency id="PowerShellStandard.Library" version="5.1.0" exclude="Build,Analyzers" />
       </group>
@@ -28,7 +28,7 @@
   </metadata>
   <files>
     <file src="images/PowerShell_64.png" target="images/" />
-    <file src="../../out/Ref/Microsoft.PowerShell.SecretManagement.dll" target="ref/netstandard2.0" />
-    <file src="../../out/Microsoft.PowerShell.SecretManagement/Microsoft.PowerShell.SecretManagement.dll" target="lib/netstandard2.0" />
+    <file src="../../out/Ref/Microsoft.PowerShell.SecretManagement.dll" target="ref/net461" />
+    <file src="../../out/Microsoft.PowerShell.SecretManagement/Microsoft.PowerShell.SecretManagement.dll" target="lib/net461" />
   </files>
 </package>

--- a/src/code/Microsoft.PowerShell.SecretManagement.csproj
+++ b/src/code/Microsoft.PowerShell.SecretManagement.csproj
@@ -11,7 +11,7 @@
     <AssemblyVersion>0.5.4.0</AssemblyVersion>
     <FileVersion>0.5.4</FileVersion>
     <InformationalVersion>0.5.4</InformationalVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">

--- a/src/code/Microsoft.PowerShell.SecretManagement.csproj
+++ b/src/code/Microsoft.PowerShell.SecretManagement.csproj
@@ -8,14 +8,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretManagement</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretManagement</AssemblyName>
-    <AssemblyVersion>0.5.4.0</AssemblyVersion>
-    <FileVersion>0.5.4</FileVersion>
-    <InformationalVersion>0.5.4</InformationalVersion>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <DefineConstants>$(DefineConstants);UNIX</DefineConstants>
+    <AssemblyVersion>0.5.5.0</AssemblyVersion>
+    <FileVersion>0.5.5</FileVersion>
+    <InformationalVersion>0.5.5</InformationalVersion>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -317,6 +317,7 @@ namespace Microsoft.PowerShell.SecretManagement
         internal const string ModuleNameStr = "ModuleName";
         internal const string ModulePathStr = "ModulePath";
         internal const string VaultParametersStr = "VaultParameters";
+        internal const string DescriptionStr = "Description";
         
         #endregion
 
@@ -349,6 +350,8 @@ namespace Microsoft.PowerShell.SecretManagement
 
         public bool IsDefault { get; }
 
+        public string Description { get; }
+
         #endregion
 
         #region Constructor
@@ -371,6 +374,7 @@ namespace Microsoft.PowerShell.SecretManagement
             ModuleName = (string) vaultInfo[ModuleNameStr];
             ModuleExtensionName = Utils.GetModuleExtensionName(ModuleName);
             ModulePath = (string) vaultInfo[ModulePathStr];
+            Description = vaultInfo.ContainsKey(DescriptionStr) ? (string) vaultInfo[DescriptionStr] : string.Empty;
 
             // Additional parameters.
             var vaultParameters = new Dictionary<string, object>();
@@ -397,6 +401,7 @@ namespace Microsoft.PowerShell.SecretManagement
             ModuleName = module.ModuleName;
             ModuleExtensionName = module.ModuleExtensionName;
             ModulePath = module.ModulePath;
+            Description = module.Description;
             VaultParameters = module.VaultParameters;
             IsDefault = module.IsDefault;
         }
@@ -688,15 +693,19 @@ namespace Microsoft.PowerShell.SecretManagement
 
         private Hashtable GetAdditionalParams(PSCmdlet cmdlet)
         {
-            bool verboseEnabled = cmdlet.MyInvocation.BoundParameters.TryGetValue("Verbose", out dynamic verbose)
-                ? verbose.IsPresent : false;
-
             var additionalParams = new Hashtable();
             foreach (var item in VaultParameters)
             {
                 additionalParams.Add(
                     key: item.Key,
                     value: item.Value);
+            }
+
+            bool verboseEnabled = cmdlet.MyInvocation.BoundParameters.TryGetValue("Verbose", out dynamic verbose)
+                ? verbose.IsPresent : false;
+            if (additionalParams.ContainsKey("Verbose"))
+            {
+                additionalParams.Remove("Verbose");
             }
             additionalParams.Add("Verbose", verboseEnabled);
 
@@ -946,12 +955,8 @@ namespace Microsoft.PowerShell.SecretManagement
           "Vaults": {
             "TestLocalBin": {
               "ModuleName": "TestLocalBin",
-              "ImplementingType": {
-                "AssemblyName": "TestLocalBin",
-                "TypeName": "TestLocalBin.TestLocalBinExtension"
-              },
               "ModulePath": "E:\\temp\\Modules\\Microsoft.PowerShell.SecretManagement\\ExtModules\\TestLocalBin",
-              "ImplementingFunctions": false,
+              "Description": "Simple local store binary extension vault module",
               "VaultParameters": {
                 "Param1": "Hello",
                 "Param2": 102
@@ -959,15 +964,11 @@ namespace Microsoft.PowerShell.SecretManagement
             },
             "TestLocalScript": {
               "ModuleName": "TestLocalScript",
-              "ImplementingType": {
-                "AssemblyName": "",
-                "TypeName": ""
-              },
-              "ImplementingFunctions": true,
+              "ModulePath": "E:\\temp\\Modules\\Microsoft.PowerShell.SecretManagement\\ExtModules\\TestLocalScript"
+              "Description": "Simple local store script extension vault module",
               "VaultParameters": {
                 "Param": "SessionId"
               },
-              "ModulePath": "E:\\temp\\Modules\\Microsoft.PowerShell.SecretManagement\\ExtModules\\TestLocalScript"
             }
           }
         }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -99,12 +99,16 @@ namespace Microsoft.PowerShell.SecretManagement
 
         public static Hashtable ConvertJsonToHashtable(string json)
         {
-            var results = PowerShellInvoker.InvokeScript<Hashtable>(
-                script: ConvertJsonToHashtableScript,
-                args: new object[] { json },
-                error: out ErrorRecord _);
+            using (var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.NewRunspace))
+            {
+                var results = PowerShellInvoker.InvokeScriptOnPowerShell<Hashtable>(
+                    script: ConvertJsonToHashtableScript,
+                    args: new object[] { json },
+                    psToUse: ps,
+                    error: out ErrorRecord _);
 
-            return (results.Count > 0) ? results[0] : null;
+                return (results.Count > 0) ? results[0] : null;
+            }
         }
 
         public static string ConvertHashtableToJson(Hashtable hashtable)

--- a/test/Microsoft.PowerShell.SecretManagement.Tests.ps1
+++ b/test/Microsoft.PowerShell.SecretManagement.Tests.ps1
@@ -55,7 +55,13 @@ Describe "Test Microsoft.PowerShell.SecretManagement module" -tags CI {
                     [hashtable] $AdditionalParameters
                 )
 
-                return $global:store.TryAdd($Name, $Secret)
+                try {
+                    $global:store.Add($Name, $Secret)
+                    return $true
+                }
+                catch { }
+
+                return $false
             }
 
             function Remove-Secret


### PR DESCRIPTION
This PR modifies the SecretManagement binary build to target the net461 framework, so that it can be compatible with WindowsPowerShell as well as PowerShell core.

The Microsoft.PowerShell.SecretManagement.Library reference library has also been re-targeted to net461 and published to nuget (version 0.5.5-preview.6), to support extension vaults such as Microsoft.PowerShell.SecretStore.

This is likely a breaking change where other extension vaults that build binaries will have to be rebuilt against the new Microsoft.PowerShell.SecretManagement.Library 0.5.5-preview.6 reference library.