### PR TITLE
Docs: Remove redundant metadata parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,7 @@ function Set-SecretInfo
     param (
         [string] $Name,
         [hashtable] $Metadata,
-        [string] $VaultName,
-        [hashtable] $Metadata
+        [string] $VaultName
     )
 
     [TestStore]::SetItemMetadata($Name, $Metadata)


### PR DESCRIPTION
Metadata Parameter was listed twice in Set-SecretInfo