### PR TITLE
Add new SBOM parameters

### DIFF
--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -113,6 +113,8 @@ stages:
         parameters:
           BuildDropPath: $(signOutPath)
           Build_Repository_Uri: 'https://github.com/powershell/secretmanagement'
+          PackageName: 'Microsoft.PowerShell.SecretManagement'
+          PackageVersion: '1.1.1'
 
     - pwsh: |
         $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'


### PR DESCRIPTION
Add `PackageName` and `PackageVersion` required parameters for SBOM generation template. The SBOM template default value for sourceScanPath, `$(Build.SourcesDirectory)`, is correct so it is not specified.