### PR TITLE
Fix missing dependency on WindowsPowerShell dotNetFramework 4.6.1

### DIFF
--- a/.ci/ci_auto.yml
+++ b/.ci/ci_auto.yml
@@ -30,7 +30,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
 
@@ -153,7 +153,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
     steps:
     - checkout: self
       clean: true

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -114,7 +114,7 @@ stages:
           BuildDropPath: $(signOutPath)
           Build_Repository_Uri: 'https://github.com/powershell/secretmanagement'
           PackageName: 'Microsoft.PowerShell.SecretManagement'
-          PackageVersion: '1.1.1'
+          PackageVersion: '1.1.2'
 
     - pwsh: |
         $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -21,7 +21,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
     - pwsh: |
@@ -204,7 +204,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
     steps:
     - checkout: self
       clean: true

--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -7,7 +7,7 @@ jobs:
   pool:
     name: 1ES
     demands:
-    - ImageOverride -equals MMS2019
+    - ImageOverride -equals PSMMS2019-Secure
   displayName: ${{ parameters.displayName }}
 
   steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix for type initialization error on WindowsPowerShell (Issue #)
+- Fix for type initialization error on WindowsPowerShell (Issue #89)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.1.2 - 2022-01-27
+
+### Fixes
+
+- Fix for type initialization error on WindowsPowerShell (Issue #)
+
+### Changes
+
+### New Features
+
 ## 1.1.1 - 2021-10-8
 
 ### Fixes

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -72,6 +72,9 @@ function DoBuild
                 Copy-Item -Path "$BuildSrcPath/${ModuleName}.pdb" -Dest "$BuildOutPath"
             }
 
+            Write-Verbose -Verbose "$BuildSrcPath/System.Runtime.InteropServices.RuntimeInformation.dll to $BuildOutPath"
+            Copy-Item -Path "$BuildSrcPath/System.Runtime.InteropServices.RuntimeInformation.dll" -Dest "$BuildOutPath"
+
             if (! (Test-Path -Path "$RefSrcPath/${ModuleName}.dll"))
             {
                 # throw "Expected ref binary was not created: $RefSrcPath/${ModuleName}.dll"

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -45,13 +45,28 @@ function DoBuild
         # build code and place it in the staging location
         Push-Location "${SrcPath}/code"
         try {
+            # Get dotnet.exe command path.
+            $dotnetCommand = Get-Command -Name 'dotnet' -ErrorAction Ignore
+
+            # Check for dotnet for Windows (we only build on Windows platforms).
+            if ($null -eq $dotnetCommand) {
+                Write-Verbose -Verbose -Message "dotnet.exe cannot be found in current path. Looking in ProgramFiles path."
+                $dotnetCommandPath = Join-Path -Path $env:ProgramFiles -ChildPath "dotnet\dotnet.exe"
+                $dotnetCommand = Get-Command -Name $dotnetCommandPath -ErrorAction Ignore
+                if ($null -eq $dotnetCommand) {
+                    throw "Dotnet.exe cannot be found: $dotnetCommandPath is unavailable for build."
+                }
+            }
+
+            Write-Verbose -Verbose -Message "dotnet.exe command found in path: $($dotnetCommand.Path)"
+
             # Check dotnet version
-            Write-Verbose -Verbose -Message "DotNet version: $(dotnet --version)"
+            Write-Verbose -Verbose -Message "DotNet version: $(& ($dotnetCommand) --version)"
 
             # Build source
             Write-Verbose -Verbose -Message "Building with configuration: $BuildConfiguration, framework: $BuildFramework"
             Write-Verbose -Verbose -Message "Building location: PSScriptRoot: $PSScriptRoot, PWD: $pwd"
-            dotnet publish --configuration $BuildConfiguration --framework $BuildFramework --output $BuildSrcPath
+            & ($dotnetCommand) publish --configuration $BuildConfiguration --framework $BuildFramework --output $BuildSrcPath
 
             # Dump build source output directory
             # $outResults = Get-ChildItem -Path "bin/${BuildConfiguration}/${BuildFramework}" -Recurse | Out-String

--- a/src/Microsoft.PowerShell.SecretManagement.psd1
+++ b/src/Microsoft.PowerShell.SecretManagement.psd1
@@ -7,7 +7,7 @@
 RootModule = '.\Microsoft.PowerShell.SecretManagement.dll'
 
 # Version number of this module.
-ModuleVersion = '1.1.1'
+ModuleVersion = '1.1.2'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/src/code/Microsoft.PowerShell.SecretManagement.Library.nuspec
+++ b/src/code/Microsoft.PowerShell.SecretManagement.Library.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.PowerShell.SecretManagement.Library</id>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <title>Microsoft.PowerShell.SecretManagement.Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft,PowerShell</owners>

--- a/src/code/Microsoft.PowerShell.SecretManagement.csproj
+++ b/src/code/Microsoft.PowerShell.SecretManagement.csproj
@@ -8,9 +8,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.SecretManagement</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.SecretManagement</AssemblyName>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
-    <FileVersion>1.1.1</FileVersion>
-    <InformationalVersion>1.1.1</InformationalVersion>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
+    <FileVersion>1.1.2</FileVersion>
+    <InformationalVersion>1.1.2</InformationalVersion>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
dotNetFramework 4.6.1 does not include the InteropServices.RuntimeInformation types, that are needed by the module.  Fix is to include the binary in the module package.

This PR also contains CI release changes to update the build image.