### PR TITLE
Fix dotnet command for ref assembly

### DIFF
--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -104,7 +104,7 @@ function DoBuild
             }
 
             # Create nuget package for reference assembly based on Microsoft.PowerShell.SecretManagement.Library.nuspec file.
-            dotnet pack --no-build --configuration $BuildConfiguration --no-restore
+            & ($dotnetCommand) pack --no-build --configuration $BuildConfiguration --no-restore
 
             # Copy ref assembly nuget package to out.
             $NuGetSrcPath = "bin/${BuildConfiguration}/Microsoft.PowerShell.SecretManagement.Library*.nupkg"


### PR DESCRIPTION
PR fixes missed place to use discovered dotnet command object for building ref assembly.