### PR TITLE
(MAINT) Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -1,0 +1,75 @@
+name: Bug report 🐛
+description: Report errors or unexpected behavior 🤔
+labels:
+  - Needs-Triage
+body:
+- type: markdown
+  attributes:
+    value: >
+      This repository is **ONLY** for issues related to SecretManagement.
+- type: checkboxes
+  attributes:
+    label: Prerequisites
+    options:
+    - label: Write a descriptive title.
+      required: true
+    - label: Make sure you are able to repro it on the [latest released version](https://www.powershellgallery.com/packages/Microsoft.PowerShell.SecretManagement)
+      required: true
+    - label: Search the existing issues.
+      required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: >
+      List of steps, sample code, failing test or link to a project that reproduces the behavior.
+      Make sure you place a stack trace inside a code (```) block to avoid linking unrelated issues.
+    placeholder: >
+      I am experiencing a problem with X.
+      I think Y should be happening but Z is actually happening.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    render: console
+    placeholder: |
+      PS> 2 + 2
+      4
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual behavior
+    render: console
+    placeholder: |
+      PS> 2 + 2
+      5
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Error details
+    description: Paste verbatim output from `Get-Error` if PowerShell returns an error.
+    render: console
+    placeholder: PS> Get-Error
+- type: textarea
+  attributes:
+    label: Environment data
+    description: Paste verbatim output from `$PSVersionTable` below.
+    render: PowerShell
+    placeholder: PS> $PSVersionTable
+  validations:
+    required: true
+- type: input
+  validations:
+    required: true
+  attributes:
+    label: Version
+    description: Specify the version of Crescendo you are using.
+- type: textarea
+  attributes:
+    label: Visuals
+    description: >
+      Please upload images or animations that can be used to reproduce issues in the area below.
+      Try the [Steps Recorder](https://support.microsoft.com/en-us/windows/record-steps-to-reproduce-a-problem-46582a9b-620f-2e36-00c9-04e25d784e47)
+      on Windows or [Screenshot](https://support.apple.com/en-us/HT208721) on macOS.

--- a/.github/ISSUE_TEMPLATE/Feature_Request.yaml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yaml
@@ -1,0 +1,22 @@
+name: Feature Request / Idea 🚀
+description: Suggest a new feature or improvement (this does not mean you have to implement it)
+labels:
+  - Issue-Enhancement
+  - Needs-Triage
+body:
+- type: textarea
+  attributes:
+    label: Summary of the new feature / enhancement
+    description: >
+      A clear and concise description of what the problem is that the
+      new feature would solve. Try formulating it in user story style
+      (if applicable).
+    placeholder: "'As a user I want X so that Y...' with X being the being the action and Y being the value of the action."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Proposed technical implementation details (optional)
+    placeholder: >
+      A clear and concise description of what you want to happen.
+      Consider providing an example experience with expected result.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PowerShell Issues
+    url: https://github.com/PowerShell/PowerShell/issues/new
+    about: PowerShell issues or suggestions.
+  - name: Windows PowerShell Issues
+    url: https://support.microsoft.com/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332
+    about: Windows PowerShell issues or suggestions.
+  - name: Support
+    url: https://github.com/PowerShell/PowerShell/blob/master/.github/SUPPORT.md
+    about: PowerShell Support Questions/Help
+  - name: Documentation Issue
+    url: https://github.com/MicrosoftDocs/PowerShell-Docs-Modules/issues/new/choose
+    about: Please open issues on documentation for SecretManagement here.


### PR DESCRIPTION
Prior to this change, the repository had no issue templates. This change introduces two new templates, one for feature requests and one for bug reports.

It also sets the configuration for the issue picker to send the user to the appropriate pages to file issues for PowerShell itself, seek support, or file a documentation issue.

While the picker page cannot be previewed, the rendered templates can:

- [Bug Report](https://github.com/PowerShell/SecretManagement/blob/7330ed241c0a3841c55661675c764e14b16b4532/.github/ISSUE_TEMPLATE/Bug_Report.yaml)
- [Feature Request](https://github.com/PowerShell/SecretManagement/blob/7330ed241c0a3841c55661675c764e14b16b4532/.github/ISSUE_TEMPLATE/Feature_Request.yaml)