### PR TITLE
Sort the results of `Get-SecretInfo` correctly 

### DIFF
--- a/src/code/SecretManagement.cs
+++ b/src/code/SecretManagement.cs
@@ -1092,15 +1092,9 @@ namespace Microsoft.PowerShell.SecretManagement
             if (results == null) { return; }
 
             // Ensure each vaults results are sorted by secret name.
-            var sortedList = new SortedDictionary<string, SecretInformation>(StringComparer.OrdinalIgnoreCase);
-            foreach (var item in results)
-            {
-                sortedList.Add(
-                    key: item.Name,
-                    value: item);
-            }
+            Array.Sort(results, new SecretInformationComparer());
 
-            foreach (var item in sortedList.Values)
+            foreach (var item in results)
             {
                 WriteObject(item);
             }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -324,6 +324,17 @@ namespace Microsoft.PowerShell.SecretManagement
 
         #endregion
     }
+    
+    /// <summary>
+    ///  Compares secret information by name.
+    /// </summary>
+    public class SecretInformationComparer : IComparer<SecretInformation>
+    {
+        public int Compare(SecretInformation x, SecretInformation y)
+        {
+            return string.Compare(x.Name, y.Name, StringComparison.Ordinal);
+        }
+    }
 
     #endregion
 


### PR DESCRIPTION
Instead of using a `SortedDictionary` which introduced a bug because it required the keys (secret names) to be unique, we just sort the array directly using a comparer that sorts by name. Fixes #95.