### PR TITLE
Remove `-Output` switch from `Invoke-Pester`

### DIFF
--- a/SecretManagement.build.ps1
+++ b/SecretManagement.build.ps1
@@ -81,7 +81,7 @@ task PackageLibrary -If { $Configuration -eq "Release" } {
 }
 
 task Test {
-    Invoke-Pester -CI -Output Diagnostic
+    Invoke-Pester -CI
 }
 
 task Build BuildModule, BuildDocs


### PR DESCRIPTION
Since it was dropped back in v4.